### PR TITLE
Add support for builtin libcurl and some other fixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 #+TITLE: zig-curl
 #+DATE: 2023-09-16T23:16:15+0800
-#+LASTMOD: 2023-09-19T08:30:18+0800
+#+LASTMOD: 2023-12-23T11:51:43+0800
 #+OPTIONS: toc:nil num:nil
 #+STARTUP: content
 
@@ -14,7 +14,7 @@ This package is in its early stage, although the core functionality works right 
 =zig-curl= only support [[https://ziglang.org/download/][Zig master]], and any contributions are welcomed. ⚒️
 #+end_quote
 
-The builtin curl consists of:
+The builtin libcurl consists of:
 - curl 8.1.1
 - mbedtls 3.4.0
 - zlib 1.2.13
@@ -24,12 +24,9 @@ The builtin curl consists of:
 const curl = @import("curl");
 
 pub fn main() !void {
-    try curl.global_init();
-    defer curl.global_deinit();
-
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer if (gpa.deinit() != .ok) @panic("leak");
+    const allocator = gpa.allocator();
 
     const easy = try curl.Easy.init(allocator, .{});
     defer easy.deinit();

--- a/README.org
+++ b/README.org
@@ -14,16 +14,24 @@ This package is in its early stage, although the core functionality works right 
 =zig-curl= only support [[https://ziglang.org/download/][Zig master]], and any contributions are welcomed. ⚒️
 #+end_quote
 
+The builtin curl consists of:
+- curl 8.1.1
+- mbedtls 3.4.0
+- zlib 1.2.13
+
 * Usage
 #+begin_src zig
-const Easy = @import("curl").Easy;
+const curl = @import("curl");
 
 pub fn main() !void {
+    try curl.global_init();
+    defer curl.global_deinit();
+
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const easy = try Easy.init(allocator);
+    const easy = try curl.Easy.init(allocator, .{});
     defer easy.deinit();
 
     const resp = try easy.get("http://httpbin.org/anything");
@@ -66,8 +74,9 @@ const curl = b.dependency("curl", .{});
 
 // add curl module to an executable.
 exe.addModule("curl", curl.module("curl"));
-// Note: since this package doesn't bundle static libcurl,
-// so users need to link to system-wide libcurl.
+// For builtin libcurl
+exe.linkLibrary(curl.artifact("curl"));
+// For system-wide libcurl
 exe.linkSystemLibrary("curl");
 exe.linkLibC();
 #+end_src

--- a/build.zig
+++ b/build.zig
@@ -7,19 +7,21 @@ const MODULE_NAME = "curl";
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
     const module = b.addModule(MODULE_NAME, .{
         .source_file = .{ .path = "src/main.zig" },
     });
 
-    const libcurl = b.dependency("libcurl", .{ .target = target });
+    const libcurl = b.dependency("libcurl", .{ .target = target, .optimize = optimize });
     b.installArtifact(libcurl.artifact("curl"));
 
-    try addExample(b, "basic", module, libcurl, target);
-    try addExample(b, "advanced", module, libcurl, target);
+    try addExample(b, "basic", module, libcurl, target, optimize);
+    try addExample(b, "advanced", module, libcurl, target, optimize);
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
+        .optimize = optimize,
     });
     main_tests.addModule(MODULE_NAME, module);
     main_tests.linkLibrary(libcurl.artifact("curl"));
@@ -35,11 +37,13 @@ fn addExample(
     curl_module: *Module,
     libcurl: *Build.Dependency,
     target: std.zig.CrossTarget,
+    optimize: std.builtin.OptimizeMode,
 ) !void {
     const exe = b.addExecutable(.{
         .name = name,
         .root_source_file = LazyPath.relative("examples/" ++ name ++ ".zig"),
         .target = target,
+        .optimize = optimize,
     });
 
     b.installArtifact(exe);

--- a/build.zig
+++ b/build.zig
@@ -11,16 +11,18 @@ pub fn build(b: *std.Build) void {
         .source_file = .{ .path = "src/main.zig" },
     });
 
-    try addExample(b, "basic", module, target);
-    try addExample(b, "advanced", module, target);
+    const libcurl = b.dependency("libcurl", .{ .target = target });
+    b.installArtifact(libcurl.artifact("curl"));
+
+    try addExample(b, "basic", module, libcurl, target);
+    try addExample(b, "advanced", module, libcurl, target);
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/main.zig" },
         .target = target,
     });
     main_tests.addModule(MODULE_NAME, module);
-    main_tests.linkSystemLibrary("curl");
-    main_tests.linkLibC();
+    main_tests.linkLibrary(libcurl.artifact("curl"));
 
     const run_main_tests = b.addRunArtifact(main_tests);
     const test_step = b.step("test", "Run library tests");
@@ -31,6 +33,7 @@ fn addExample(
     b: *std.Build,
     comptime name: []const u8,
     curl_module: *Module,
+    libcurl: *Build.Dependency,
     target: std.zig.CrossTarget,
 ) !void {
     const exe = b.addExecutable(.{
@@ -41,8 +44,7 @@ fn addExample(
 
     b.installArtifact(exe);
     exe.addModule(MODULE_NAME, curl_module);
-    exe.linkSystemLibrary("curl");
-    exe.linkLibC();
+    exe.linkLibrary(libcurl.artifact("curl"));
 
     const run_step = b.step("run-" ++ name, std.fmt.comptimePrint("Run {s} example", .{name}));
     run_step.dependOn(&b.addRunArtifact(exe).step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = "zig-curl",
+    .version = "0.1.0",
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+    },
+    .dependencies = .{
+        .libcurl = .{
+            .url = "https://github.com/Cloudef/zigcurl/archive/e9e726131d3eb80c02d20b7ee5ca6935324d6697.tar.gz",
+            .hash = "1220970ad7d9b96b3464fc12c1e67998881bc4d07c03b8b7d75a5367e4c9991ef099",
+        },
+    },
+}

--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -34,7 +34,7 @@ fn put_with_custom_header(allocator: Allocator, easy: Easy) !void {
         try h.add("Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
         break :blk h;
     };
-    var req = curl.Request(@TypeOf(body)).init("http://httpbin.org/anything/zig-curl", body, .{
+    var req = curl.Request(@TypeOf(body)).init("https://httpbin.org/anything/zig-curl", body, .{
         .method = .PUT,
         .header = header,
         .verbose = true,
@@ -66,7 +66,7 @@ fn put_with_custom_header(allocator: Allocator, easy: Easy) !void {
                 .age = 15,
             },
             .method = "PUT",
-            .url = "http://httpbin.org/anything/zig-curl",
+            .url = "https://httpbin.org/anything/zig-curl",
         },
     );
 
@@ -89,7 +89,7 @@ fn post_mutli_part(easy: Easy) !void {
     try multi_part.add_part("build.zig", .{ .file = "build.zig" });
     try multi_part.add_part("readme", .{ .file = "README.org" });
 
-    var req = curl.Request(void).init("http://httpbin.org/anything/mp", {}, .{
+    var req = curl.Request(void).init("https://httpbin.org/anything/mp", {}, .{
         .method = .PUT,
         .multi_part = multi_part,
         .verbose = true,

--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -107,7 +107,7 @@ pub fn main() !void {
     defer if (gpa.deinit() != .ok) @panic("leak");
     const allocator = gpa.allocator();
 
-    const easy = try Easy.init(allocator);
+    const easy = try Easy.init(allocator, .{});
     defer easy.deinit();
 
     curl.print_libcurl_version();

--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -24,7 +24,7 @@ fn put_with_custom_header(allocator: Allocator, easy: Easy) !void {
     var stream = std.io.fixedBufferStream(
         \\ {"name": "John", "age": 15}
     );
-    var body = stream.reader();
+    const body = stream.reader();
 
     const header = blk: {
         var h = curl.RequestHeader.init(allocator);
@@ -105,7 +105,7 @@ fn post_mutli_part(easy: Easy) !void {
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer if (gpa.deinit() != .ok) @panic("leak");
-    var allocator = gpa.allocator();
+    const allocator = gpa.allocator();
 
     const easy = try Easy.init(allocator);
     defer easy.deinit();

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
     defer if (gpa.deinit() != .ok) @panic("leak");
     const allocator = gpa.allocator();
 
-    const easy = try Easy.init(allocator);
+    const easy = try Easy.init(allocator, .{});
     defer easy.deinit();
 
     println("GET demo");

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -6,7 +6,7 @@ const curl = @import("curl");
 const Easy = curl.Easy;
 
 fn get(easy: Easy) !void {
-    const resp = try easy.get("http://httpbin.org/anything");
+    const resp = try easy.get("https://httpbin.org/anything");
     defer resp.deinit();
 
     std.debug.print("Status code: {d}\nBody: {s}\n", .{
@@ -19,7 +19,7 @@ fn post(easy: Easy) !void {
     var payload = std.io.fixedBufferStream(
         \\{"name": "John", "age": 15}
     );
-    const resp = try easy.post("http://httpbin.org/anything", "application/json", payload.reader());
+    const resp = try easy.post("https://httpbin.org/anything", "application/json", payload.reader());
     defer resp.deinit();
 
     std.debug.print("Status code: {d}\nBody: {s}\n", .{

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -31,7 +31,7 @@ fn post(easy: Easy) !void {
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer if (gpa.deinit() != .ok) @panic("leak");
-    var allocator = gpa.allocator();
+    const allocator = gpa.allocator();
 
     const easy = try Easy.init(allocator);
     defer easy.deinit();

--- a/src/easy.zig
+++ b/src/easy.zig
@@ -288,11 +288,11 @@ pub fn do(self: Self, req: anytype) !Response {
 
     try checkCode(c.curl_easy_perform(self.handle));
 
-    var status_code: i32 = 0;
+    var status_code: c_long = 0;
     try checkCode(c.curl_easy_getinfo(self.handle, c.CURLINFO_RESPONSE_CODE, &status_code));
 
     return .{
-        .status_code = status_code,
+        .status_code = @truncate(status_code),
         .body = resp_buffer,
         .handle = self.handle,
         .allocator = self.allocator,

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -39,5 +39,5 @@ pub fn checkCode(code: c.CURLcode) !void {
     // https://curl.se/libcurl/c/libcurl-errors.html
     std.log.debug("curl err code:{d}, msg:{s}\n", .{ code, c.curl_easy_strerror(code) });
 
-    return error.Unepxected;
+    return error.Unexpected;
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const Encoder = std.base64.standard.Encoder;
+
+pub fn encode_base64(allocator: Allocator, input: []const u8) ![]const u8 {
+    const encoded_len = Encoder.calcSize(input.len);
+    const dest = try allocator.alloc(u8, encoded_len);
+
+    return Encoder.encode(dest, input);
+}


### PR DESCRIPTION
* Fix crash on easy.do() which does not pass the proper type to curl
* Fix compile on latest zig
* Use standard optimize options in built.zig
* Fix typo in errors.zig
* Allow the use of certificates in std.crypto.Certificate.Bundle instead of default one
* Include builtin libcurl compiled against mbedTls, the use of std.crypto.Certificate.Bundle is required, or CURLOPT_CAINFO should be used to point to cacert bundle.