### PR TITLE
Fix potential memory leak when `curl_slist_append` fails

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -51,7 +51,9 @@ pub const Headers = struct {
         const header = try std.fmt.allocPrintZ(self.allocator, "{s}: {s}", .{ name, value });
         defer self.allocator.free(header);
 
-        self.headers = c.curl_slist_append(self.headers, header);
+        self.headers = c.curl_slist_append(self.headers, header) orelse {
+            return errors.HeaderError.OutOfMemory;
+        };
     }
 };
 


### PR DESCRIPTION
`curl_slist_append()` returns null on failure, and it won't free the original list when this happens. Overwriting `self.headers` directly might leak the original list.

Reasons for the failure are not documented. But the function can only fail on allocation failure according to the source code. So I chose `OutOfMemory`.