### PR TITLE
Add support for iterating headers

### DIFF
--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -129,47 +129,15 @@ fn iterateHeaders(easy: Easy) !void {
 
     std.debug.print("Iterating X-Foo only...\n", .{});
     {
-        const Entry = struct {
-            name: []const u8,
-            value: []const u8,
-            visited: bool = false,
-        };
-        var entries = [_]Entry{
-            .{ .name = "X-Foo", .value = "Hello" },
-            .{ .name = "X-Foo", .value = "World" },
-            .{ .name = "x-fOO", .value = "42" },
-        };
+        var count: usize = 0;
 
         var iter = try resp.iterateHeaders(.{ .name = "X-Foo" });
         while (try iter.next()) |header| {
-            const name = header.name;
-            const value = header.get();
-            std.debug.print("  {s}: {s}\n", .{ name, value });
-
-            for (&entries) |*entry| {
-                if (entry.visited) continue;
-                if (!std.mem.eql(u8, entry.name, name)) continue;
-                if (!std.mem.eql(u8, entry.value, value)) continue;
-                entry.visited = true;
-                break;
-            } else {
-                std.debug.print(
-                    "Extra X-Foo header `{s}: {s}`\n",
-                    .{ name, value },
-                );
-                try std.testing.expect(false);
-            }
+            std.debug.print("  {s}: {s}\n", .{ header.name, header.get() });
+            count += 1;
         }
 
-        for (entries) |entry| {
-            if (!entry.visited) {
-                std.debug.print(
-                    "Missing X-Foo header `{s}: {s}`\n",
-                    .{ entry.name, entry.value },
-                );
-                try std.testing.expect(false);
-            }
-        }
+        try std.testing.expect(count == 3);
     }
 }
 

--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -177,13 +177,8 @@ fn iterateRedirectedHeaders(easy: Easy) !void {
     // Reset old options, e.g. headers.
     easy.reset();
 
-    try easy.setUrl("https://httpbin.org/redirect/3");
-    var buf = curl.Buffer.init(easy.allocator);
-    try easy.setWritedata(&buf);
-    try easy.setWritefunction(curl.bufferWriteCallback);
     try easy.setFollowLocation(true);
-
-    var resp = try easy.perform();
+    const resp = try easy.get("https://httpbin.org/redirect/3");
     defer resp.deinit();
 
     const redirects = try resp.getRedirectCount();

--- a/examples/advanced.zig
+++ b/examples/advanced.zig
@@ -112,6 +112,92 @@ fn postMutliPart(easy: Easy) !void {
     std.debug.print("resp:{s}\n", .{resp.body.?.items});
 }
 
+fn iterateHeaders(easy: Easy) !void {
+    // Reset old options, e.g. headers.
+    easy.reset();
+
+    const resp = try easy.get("https://httpbin.org/response-headers?X-Foo=Hello&X-Foo=World&x-fOO=42");
+    defer resp.deinit();
+
+    std.debug.print("Iterating all headers...\n", .{});
+    {
+        var iter = try resp.iterateHeaders(.{});
+        while (try iter.next()) |header| {
+            std.debug.print("  {s}: {s}\n", .{ header.name, header.get() });
+        }
+    }
+
+    std.debug.print("Iterating X-Foo only...\n", .{});
+    {
+        const Entry = struct {
+            name: []const u8,
+            value: []const u8,
+            visited: bool = false,
+        };
+        var entries = [_]Entry{
+            .{ .name = "X-Foo", .value = "Hello" },
+            .{ .name = "X-Foo", .value = "World" },
+            .{ .name = "x-fOO", .value = "42" },
+        };
+
+        var iter = try resp.iterateHeaders(.{ .name = "X-Foo" });
+        while (try iter.next()) |header| {
+            const name = header.name;
+            const value = header.get();
+            std.debug.print("  {s}: {s}\n", .{ name, value });
+
+            for (&entries) |*entry| {
+                if (entry.visited) continue;
+                if (!std.mem.eql(u8, entry.name, name)) continue;
+                if (!std.mem.eql(u8, entry.value, value)) continue;
+                entry.visited = true;
+                break;
+            } else {
+                std.debug.print(
+                    "Extra X-Foo header `{s}: {s}`\n",
+                    .{ name, value },
+                );
+                try std.testing.expect(false);
+            }
+        }
+
+        for (entries) |entry| {
+            if (!entry.visited) {
+                std.debug.print(
+                    "Missing X-Foo header `{s}: {s}`\n",
+                    .{ entry.name, entry.value },
+                );
+                try std.testing.expect(false);
+            }
+        }
+    }
+}
+
+fn iterateRedirectedHeaders(easy: Easy) !void {
+    // Reset old options, e.g. headers.
+    easy.reset();
+
+    try easy.setUrl("https://httpbin.org/redirect/3");
+    var buf = curl.Buffer.init(easy.allocator);
+    try easy.setWritedata(&buf);
+    try easy.setWritefunction(curl.bufferWriteCallback);
+    try easy.setFollowLocation(true);
+
+    var resp = try easy.perform();
+    defer resp.deinit();
+
+    const redirects = try resp.getRedirectCount();
+    std.debug.print("Redirected {} times.\n", .{redirects});
+
+    for (0..redirects + 1) |i| {
+        std.debug.print("Request #{} headers:\n", .{i});
+        var iter = try resp.iterateHeaders(.{ .request = i });
+        while (try iter.next()) |header| {
+            std.debug.print("  {s}: {s}\n", .{ header.name, header.get() });
+        }
+    }
+}
+
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
 
@@ -127,4 +213,16 @@ pub fn main() !void {
     println("PUT with custom header demo");
     try putWithCustomHeader(allocator, easy);
     try postMutliPart(easy);
+
+    println("Iterate headers demo");
+    iterateHeaders(easy) catch |err| switch (err) {
+        error.NoCurlHeaderSupport => std.debug.print("No header support, skipping...\n", .{}),
+        else => return err,
+    };
+
+    println("Redirected headers demo");
+    iterateRedirectedHeaders(easy) catch |err| switch (err) {
+        error.NoCurlHeaderSupport => std.debug.print("No header support, skipping...\n", .{}),
+        else => return err,
+    };
 }

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -102,7 +102,7 @@ pub const Response = struct {
         const code = c.curl_easy_header(self.handle, name.ptr, 0, c.CURLH_HEADER, -1, &header);
         return if (errors.headerErrorFrom(code)) |err|
             switch (err) {
-                error.Missing => null,
+                error.Missing, error.NoHeaders => null,
                 else => err,
             }
         else
@@ -141,7 +141,7 @@ pub const Response = struct {
                         request,
                         &self.c_header,
                     ))) |err| return switch (err) {
-                        error.Missing => null,
+                        error.Missing, error.NoHeaders => null,
                         else => err,
                     };
                     const c_header = self.c_header orelse unreachable;

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -125,9 +125,14 @@ pub const Response = struct {
 
             const request: c_int = if (self.request) |v| @intCast(v) else -1;
 
-            if (self.c_header == null) {
-                // Slightly more efficient than `curl_easy_nextheader`.
-                if (self.name) |filter_name| {
+            if (self.name) |filter_name| {
+                if (self.c_header) |c_header| {
+                    // Stop early.
+                    if (c_header.*.index + 1 == c_header.*.amount) {
+                        return null;
+                    }
+                } else {
+                    // `curl_easy_header` is slightly more performant for the first header.
                     if (errors.headerErrorFrom(c.curl_easy_header(
                         self.handle,
                         filter_name.ptr,

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -128,14 +128,17 @@ pub const Response = struct {
             if (self.c_header == null) {
                 // Slightly more efficient than `curl_easy_nextheader`.
                 if (self.name) |filter_name| {
-                    try checkCode(c.curl_easy_header(
+                    if (errors.headerErrorFrom(c.curl_easy_header(
                         self.handle,
                         filter_name.ptr,
                         0,
                         c.CURLH_HEADER,
                         request,
                         &self.c_header,
-                    ));
+                    ))) |err| return switch (err) {
+                        error.Missing => null,
+                        else => err,
+                    };
                     const c_header = self.c_header orelse unreachable;
                     return Header{
                         .c_header = c_header,


### PR DESCRIPTION
Rationale: `Response.getHeader()` does not work with multiple headers sharing the same name (which is not uncommon, e.g. the `Set-Cookie` header).

Mainly adds `Response.iterateHeaders(options)` which returns a `HeaderIterator`. See `examples/advanced.zig` for usage.

It also supports iterating over headers of redirected requests. Added the following methods for easier testing:

- `Response.getRedirectCount()`
- `Easy.setFollowLocation(enable)`