### PR TITLE
Pass address of ca blob to setopt

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -465,7 +465,7 @@ pub fn setCommonOpts(self: Self) !void {
             .len = bundle.items.len,
             .flags = c.CURL_BLOB_NOCOPY,
         };
-        try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_CAINFO_BLOB, blob));
+        try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_CAINFO_BLOB, &blob));
     }
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_TIMEOUT_MS, self.timeout_ms));
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_USERAGENT, self.user_agent.ptr));


### PR DESCRIPTION
As per https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html

For some reason this was working completely fine when I ran on macOS, but then I tried running the same thing on linux and would always get return code 43 (bad arg).