### PR TITLE
feat(easy): add support for IPRESOLVE option

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -384,6 +384,16 @@ pub fn setPassword(self: Self, password: [:0]const u8) !void {
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_PASSWORD, password.ptr));
 }
 
+pub const IpResolve = enum(c_int) {
+    whatever = c.CURL_IPRESOLVE_WHATEVER,
+    v4 = c.CURL_IPRESOLVE_V4,
+    v6 = c.CURL_IPRESOLVE_V6,
+};
+
+pub fn setIpResolve(self: Self, ipr: IpResolve) !void {
+    try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_IPRESOLVE, @intFromEnum(ipr)));
+}
+
 /// Perform sends an HTTP request and returns an HTTP response.
 pub fn perform(self: Self) !Response {
     try self.setCommonOpts();


### PR DESCRIPTION
Option to restrict curl to use a specific IP version, i.e. only go over _IPv4_, _IPv6_, or _whatever_.

I have a use case where I ping a HTTP API to determine both of my public-facing IP addresses, so I needed it for that.