### PR TITLE
fileWriteCallback function added

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -480,7 +480,8 @@ pub fn fileWriteCallback(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_file
     const real_size = size * nmemb;
     var file: *std.fs.File = @alignCast(@ptrCast(user_file));
     var typed_data: [*]u8 = @ptrCast(ptr);
-    return file.write(typed_data[0..real_size]) catch return 0;
+    _ = file.write(typed_data[0..real_size]) catch return 0;
+    return real_size;
 }
 
 pub fn setCommonOpts(self: Self) !void {

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -473,6 +473,16 @@ pub fn bufferWriteCallback(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_da
     return real_size;
 }
 
+/// Used for write response via `std.fs.File` type.
+// https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+// size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userfile);
+pub fn fileWriteCallback(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_file: *anyopaque) callconv(.C) c_uint {
+    const real_size = size * nmemb;
+    var file: *std.fs.File = @alignCast(@ptrCast(user_file));
+    var typed_data: [*]u8 = @ptrCast(ptr);
+    return file.write(typed_data[0..real_size]) catch return 0;
+}
+
 pub fn setCommonOpts(self: Self) !void {
     if (self.ca_bundle) |bundle| {
         // https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html

--- a/src/root.zig
+++ b/src/root.zig
@@ -5,6 +5,7 @@ const checkCode = @import("errors.zig").checkCode;
 pub const Easy = @import("Easy.zig");
 pub const Multi = @import("Multi.zig");
 pub const bufferWriteCallback = Easy.bufferWriteCallback;
+pub const fileWriteCallback = Easy.fileWriteCallback;
 pub const printLibcurlVersion = util.printLibcurlVersion;
 pub const hasParseHeaderSupport = util.hasParseHeaderSupport;
 pub const urlEncode = util.urlEncode;


### PR DESCRIPTION
Hi,

I added a function **fileWriteCallback** to write response to a file instead of a Buffer.
I use this in a personal project and it works fine.

## Usage
```zig
var output_file = try std.fs.createFileAbsolute("response.txt", .{});
defer output_file.close();

// init Easy omitted
try easy.setWritefunction(curl.fileWriteCallback);
try easy.setWritedata(&output_file);

var resp = try easy.perform();
defer resp.deinit();
```