### PR TITLE
insecure fix (It was working backwards)

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -395,7 +395,7 @@ pub fn setIpResolve(self: Self, ipr: IpResolve) !void {
 }
 
 pub fn setInsecure(self: Self, enable: bool) !void {
-    const param: c_long = @intCast(@intFromBool(enable));
+    const param: c_long = @intCast(@intFromBool(!enable));
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_SSL_VERIFYPEER, param));
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_SSL_VERIFYHOST, param));
 }


### PR DESCRIPTION
I modified setInsecure because it was working backwards.
When setInsecure is true the c_long param must be 0L