### PR TITLE
feature: added function fetchFile

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .curl,
-    .fingerprint = 0x3e01b4de1538b3f,
+    .fingerprint = 0x3e01b4ddef29ee1,
     .version = "0.2.0",
     .paths = .{
         "src",

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -31,6 +31,25 @@ fn get(allocator: Allocator, easy: Easy) !void {
             body,
         });
     }
+
+    {
+        println("GET with file");
+        var file = try std.fs.cwd().createFile("resp.txt", .{ .read = true, .truncate = true });
+
+        defer file.close();
+        const resp = try easy.fetchFile("https://httpbin.org/anything", &file, .{});
+        defer resp.deinit();
+
+        try file.seekTo(0);
+        const body = try file.readToEndAlloc(allocator, (try file.stat()).size);
+        defer allocator.free(body);
+        std.debug.print("Status code: {d}\nBody: {s}\n", .{
+            resp.status_code,
+            body,
+        });
+
+        try std.fs.cwd().deleteFile("resp.txt");
+    }
 }
 
 fn post(allocator: Allocator, easy: Easy) !void {

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -506,6 +506,8 @@ pub fn fetch(
     return try self.perform();
 }
 
+/// Fetch issues a request to the specified URL.
+/// Response body is written to the specified file.
 pub fn fetchFile(
     self: Self,
     url: [:0]const u8,


### PR DESCRIPTION
fetch directly to a file using the `Easy.fetchFile` function.
Useful for wirting directly to files, when the response might blow up memory usage.