### PR TITLE
Upgrade to zig 0.15.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        zig-version: [0.14.0]
+        zig-version: [0.15.1]
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         zig-version: [0.15.1]
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
       - uses: actions/setup-go@v5
@@ -64,7 +64,7 @@ jobs:
         zig-version: [0.15.1]
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
       - name: Set Environment Variables

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        zig-version: [0.14.0]
+        zig-version: [0.15.1]
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@v3
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.15.1
       - name: Generate docs
         run: |
           make docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.1
       - name: Generate docs

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
 #+OPTIONS: toc:nil num:nil
 #+STARTUP: content
 
-[[https://img.shields.io/badge/zig%20version-0.14.0-blue.svg]]
+[[https://img.shields.io/badge/zig%20version-0.15.0-blue.svg]]
 [[https://img.shields.io/badge/zig%20version-master-blue.svg]]
 [[https://github.com/jiacai2050/zig-curl/actions/workflows/CI.yml][https://github.com/jiacai2050/zig-curl/actions/workflows/CI.yml/badge.svg]]
 [[https://ci.codeberg.org/repos/13257][https://ci.codeberg.org/api/badges/13257/status.svg]]

--- a/libs/curl.zig
+++ b/libs/curl.zig
@@ -1,11 +1,15 @@
 const std = @import("std");
 
 pub fn create(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) ?*std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "curl",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .root_source_file = null,
+        }),
     });
     const curl_dep = b.lazyDependency("curl", .{
         .target = target,

--- a/libs/mbedtls.zig
+++ b/libs/mbedtls.zig
@@ -2,11 +2,15 @@ const std = @import("std");
 const ResolvedTarget = std.Build.ResolvedTarget;
 
 pub fn create(b: *std.Build, target: ResolvedTarget, optimize: std.builtin.OptimizeMode) ?*std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "mbedtls",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .root_source_file = null,
+        }),
     });
 
     const mbedtls_dep = b.lazyDependency("mbedtls", .{

--- a/libs/mbedtls.zig
+++ b/libs/mbedtls.zig
@@ -9,7 +9,6 @@ pub fn create(b: *std.Build, target: ResolvedTarget, optimize: std.builtin.Optim
             .target = target,
             .optimize = optimize,
             .link_libc = true,
-            .root_source_file = null,
         }),
     });
 

--- a/libs/zlib.zig
+++ b/libs/zlib.zig
@@ -8,7 +8,6 @@ pub fn create(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.bui
             .target = target,
             .optimize = optimize,
             .link_libc = true,
-            .root_source_file = null,
         }),
     });
     const zlib_dep = b.lazyDependency("zlib", .{

--- a/libs/zlib.zig
+++ b/libs/zlib.zig
@@ -1,11 +1,15 @@
 const std = @import("std");
 
 pub fn create(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) ?*std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "z",
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .root_source_file = null,
+        }),
     });
     const zlib_dep = b.lazyDependency("zlib", .{
         .target = target,

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -241,7 +241,7 @@ pub const Upload = struct {
     }
 
     pub fn readFunction(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.c) c_uint {
-        const up: *Upload = @alignCast(@ptrCast(user_data));
+        const up: *Upload = @ptrCast(@alignCast(user_data));
         const max_length = @min(size * nmemb, up.file_len);
         var buf: [*]u8 = @ptrCast(ptr);
         const n = up.file.read(buf[0..max_length]) catch |e| {
@@ -373,7 +373,7 @@ pub fn setAnyWriter(
         fn write(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.c) c_uint {
             const real_size = size * nmemb;
             const data = (@as([*]const u8, @ptrCast(ptr)))[0..real_size];
-            const writer: *const AnyWriter = @alignCast(@ptrCast(user_data));
+            const writer: *const AnyWriter = @ptrCast(@alignCast(user_data));
             const ret = writer.write(data) catch {
                 return 0; // Indicate an error
             };

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -241,7 +241,7 @@ pub const Upload = struct {
     }
 
     pub fn readFunction(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.c) c_uint {
-        const up: *Upload = @ptrCast(@alignCast(user_data));
+        const up: *Upload = @alignCast(@ptrCast(user_data));
         const max_length = @min(size * nmemb, up.file_len);
         var buf: [*]u8 = @ptrCast(ptr);
         const n = up.file.read(buf[0..max_length]) catch |e| {
@@ -373,7 +373,7 @@ pub fn setAnyWriter(
         fn write(ptr: [*c]c_char, size: c_uint, nmemb: c_uint, user_data: *anyopaque) callconv(.c) c_uint {
             const real_size = size * nmemb;
             const data = (@as([*]const u8, @ptrCast(ptr)))[0..real_size];
-            const writer: *const AnyWriter = @ptrCast(@alignCast(user_data));
+            const writer: *const AnyWriter = @alignCast(@ptrCast(user_data));
             const ret = writer.write(data) catch {
                 return 0; // Indicate an error
             };

--- a/src/types.zig
+++ b/src/types.zig
@@ -16,7 +16,7 @@ const Allocator = std.mem.Allocator;
 //     ctx: *anyopaque,
 // };
 
-pub const ResizableBuffer = std.ArrayList(u8);
+pub const ResizableBuffer = std.array_list.Managed(u8);
 
 pub const FixedResponseWriter = struct {
     buffer: []u8,
@@ -35,7 +35,7 @@ pub const FixedResponseWriter = struct {
         w: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @alignCast(@constCast(@ptrCast(w)));
+        var writer: *Self = @ptrCast(@alignCast(@constCast(w)));
         if (writer.size + data.len > writer.buffer.len) {
             return error.BufferOverflow;
         }
@@ -70,7 +70,7 @@ pub const ResizableResponseWriter = struct {
         any: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @alignCast(@constCast(@ptrCast(any)));
+        var writer: *Self = @ptrCast(@alignCast(@constCast(any)));
         try writer.buffer.appendSlice(data);
         return data.len;
     }

--- a/src/types.zig
+++ b/src/types.zig
@@ -35,7 +35,7 @@ pub const FixedResponseWriter = struct {
         w: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @ptrCast(@alignCast(@constCast(w)));
+        var writer: *Self = @alignCast(@constCast(@ptrCast(w)));
         if (writer.size + data.len > writer.buffer.len) {
             return error.BufferOverflow;
         }
@@ -70,7 +70,7 @@ pub const ResizableResponseWriter = struct {
         any: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @ptrCast(@alignCast(@constCast(any)));
+        var writer: *Self = @alignCast(@constCast(@ptrCast(any)));
         try writer.buffer.appendSlice(data);
         return data.len;
     }

--- a/src/types.zig
+++ b/src/types.zig
@@ -35,7 +35,7 @@ pub const FixedResponseWriter = struct {
         w: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @alignCast(@constCast(@ptrCast(w)));
+        var writer: *Self = @ptrCast(@alignCast(@constCast(w)));
         if (writer.size + data.len > writer.buffer.len) {
             return error.BufferOverflow;
         }
@@ -70,7 +70,7 @@ pub const ResizableResponseWriter = struct {
         any: *const anyopaque,
         data: []const u8,
     ) anyerror!usize {
-        var writer: *Self = @alignCast(@constCast(@ptrCast(any)));
+        var writer: *Self = @ptrCast(@alignCast(@constCast(any)));
         try writer.buffer.appendSlice(data);
         return data.len;
     }


### PR DESCRIPTION


`zig build run-basic` is failing on main with 0.14.1. Not sure if this is intentional. All other examples are working in this PR, as well as tests.

```
error: Unexpected
/Users/gordoncassie/sites/zig-curl/src/errors.zig:42:5: 0x104934423 in checkCode (basic)
    return error.Unexpected;
    ^
/Users/gordoncassie/sites/zig-curl/src/Easy.zig:423:5: 0x10493507f in perform (basic)
    try checkCode(c.curl_easy_perform(self.handle));
    ^
/Users/gordoncassie/sites/zig-curl/src/Easy.zig:487:12: 0x104936da3 in upload (basic)
    return try self.perform();
           ^
/Users/gordoncassie/sites/zig-curl/examples/basic.zig:61:18: 0x104936fa7 in upload (basic)
    const resp = try easy.upload(LOCAL_SERVER_ADDR ++ "/anything", path, writer.asAny());
                 ^
/Users/gordoncassie/sites/zig-curl/examples/basic.zig:91:5: 0x1049375cf in main (basic)
    try upload(allocator, easy);
    ```
