### PR TITLE
Add support for selecting HTTP version w/ easy

### DIFF
--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -20,6 +20,46 @@ timeout_ms: usize,
 user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
+pub const HttpVersion = enum {
+    @"HTTP/1.0",
+    @"HTTP/1.1",
+    @"HTTP/2",
+    @"HTTP/2TLS",
+    @"HTTP/2_PRIOR_KNOWLEDGE",
+    @"HTTP/3",
+    @"HTTP/3_ONLY",
+    @"HTTP/LAST",
+
+    fn asCurlType(self: HttpVersion) c_int {
+        switch (self) {
+            .@"HTTP/1.0" => {
+                return c.CURL_HTTP_VERSION_1_0;
+            },
+            .@"HTTP/1.1" => {
+                return c.CURL_HTTP_VERSION_1_1;
+            },
+            .@"HTTP/2" => {
+                return c.CURL_HTTP_VERSION_2_0;
+            },
+            .@"HTTP/2TLS" => {
+                return c.CURL_HTTP_VERSION_2TLS;
+            },
+            .@"HTTP/2_PRIOR_KNOWLEDGE" => {
+                return c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE;
+            },
+            .@"HTTP/3" => {
+                return c.CURL_HTTP_VERSION_3;
+            },
+            .@"HTTP/3_ONLY" => {
+                return c.CURL_HTTP_VERSION_3ONLY;
+            },
+            .@"HTTP/LAST" => {
+                return c.CURL_HTTP_VERSION_LAST;
+            },
+        }
+    }
+};
+
 pub const Method = enum {
     GET,
     POST,
@@ -317,6 +357,13 @@ pub fn setUpload(self: Self, up: *Upload) !void {
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_UPLOAD, @as(c_int, 1)));
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_READFUNCTION, Upload.readFunction));
     try checkCode(c.curl_easy_setopt(self.handle, c.CURLOPT_READDATA, up));
+}
+
+pub fn setHttpVersion(self: Self, version: HttpVersion) !void {
+    try checkCode(c.curl_easy_setopt(
+        self.handle,
+        version.asCurlType(),
+    ));
 }
 
 pub fn setFollowLocation(self: Self, enable: bool) !void {

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -21,7 +21,7 @@ user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
 pub const HttpVersion = enum(c_long) {
-    none = c. CURL_HTTP_VERSION_NONE,
+    none = c.CURL_HTTP_VERSION_NONE,
     http1_0 = c.CURL_HTTP_VERSION_1_0,
     http1_1 = c.CURL_HTTP_VERSION_1_1,
     http2 = c.CURL_HTTP_VERSION_2_0,

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -28,7 +28,6 @@ pub const HttpVersion = enum(c_int) {
     http2_prior_knowledge = c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE,
     http3 = c.CURL_HTTP_VERSION_3,
     http3_only = c.CURL_HTTP_VERSION_3ONLY,
-    last = c.CURL_HTTP_VERSION_LAST,
 };
 
 pub const Method = enum {

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -334,7 +334,7 @@ pub fn setHttpVersion(self: Self, version: HttpVersion) !void {
     try checkCode(c.curl_easy_setopt(
         self.handle,
         c.CURLOPT_HTTP_VERSION,
-        version,
+        @intFromEnum(version),
     ));
 }
 

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -20,7 +20,7 @@ timeout_ms: usize,
 user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
-pub const HttpVersion = enum(c_int) {
+pub const HttpVersion = enum(c_long) {
     http1_0 = c.CURL_HTTP_VERSION_1_0,
     http1_1 = c.CURL_HTTP_VERSION_1_1,
     http2 = c.CURL_HTTP_VERSION_2_0,

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -21,13 +21,13 @@ user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
 pub const HttpVersion = enum(c_int) {
-    @"HTTP/1.0" = c.CURL_HTTP_VERSION_1_0,
-    @"HTTP/1.1" = c.CURL_HTTP_VERSION_1_1,
-    @"HTTP/2" = c.CURL_HTTP_VERSION_2_0,
-    @"HTTP/2_TLS" = c.CURL_HTTP_VERSION_2TLS,
-    @"HTTP/2_PRIOR_KNOWLEDGE" = c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE,
-    @"HTTP/3" = c.CURL_HTTP_VERSION_3,
-    @"HTTP/3_ONLY" = c.CURL_HTTP_VERSION_3ONLY,
+    http1_0 = c.CURL_HTTP_VERSION_1_0,
+    http1_1 = c.CURL_HTTP_VERSION_1_1,
+    http2 = c.CURL_HTTP_VERSION_2_0,
+    http2_tls = c.CURL_HTTP_VERSION_2TLS,
+    http2_prior_knowledge = c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE,
+    http3 = c.CURL_HTTP_VERSION_3,
+    http3_only = c.CURL_HTTP_VERSION_3ONLY,
     last = c.CURL_HTTP_VERSION_LAST,
 };
 

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -20,44 +20,15 @@ timeout_ms: usize,
 user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
-pub const HttpVersion = enum {
-    @"HTTP/1.0",
-    @"HTTP/1.1",
-    @"HTTP/2",
-    @"HTTP/2TLS",
-    @"HTTP/2_PRIOR_KNOWLEDGE",
-    @"HTTP/3",
-    @"HTTP/3_ONLY",
-    @"HTTP/LAST",
-
-    fn asCurlType(self: HttpVersion) c_int {
-        switch (self) {
-            .@"HTTP/1.0" => {
-                return c.CURL_HTTP_VERSION_1_0;
-            },
-            .@"HTTP/1.1" => {
-                return c.CURL_HTTP_VERSION_1_1;
-            },
-            .@"HTTP/2" => {
-                return c.CURL_HTTP_VERSION_2_0;
-            },
-            .@"HTTP/2TLS" => {
-                return c.CURL_HTTP_VERSION_2TLS;
-            },
-            .@"HTTP/2_PRIOR_KNOWLEDGE" => {
-                return c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE;
-            },
-            .@"HTTP/3" => {
-                return c.CURL_HTTP_VERSION_3;
-            },
-            .@"HTTP/3_ONLY" => {
-                return c.CURL_HTTP_VERSION_3ONLY;
-            },
-            .@"HTTP/LAST" => {
-                return c.CURL_HTTP_VERSION_LAST;
-            },
-        }
-    }
+pub const HttpVersion = enum(c_int) {
+    @"HTTP/1.0" = c.CURL_HTTP_VERSION_1_0,
+    @"HTTP/1.1" = c.CURL_HTTP_VERSION_1_1,
+    @"HTTP/2" = c.CURL_HTTP_VERSION_2_0,
+    @"HTTP/2_TLS" = c.CURL_HTTP_VERSION_2TLS,
+    @"HTTP/2_PRIOR_KNOWLEDGE" = c.CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE,
+    @"HTTP/3" = c.CURL_HTTP_VERSION_3,
+    @"HTTP/3_ONLY" = c.CURL_HTTP_VERSION_3ONLY,
+    last = c.CURL_HTTP_VERSION_LAST,
 };
 
 pub const Method = enum {
@@ -363,7 +334,7 @@ pub fn setHttpVersion(self: Self, version: HttpVersion) !void {
     try checkCode(c.curl_easy_setopt(
         self.handle,
         c.CURLOPT_HTTP_VERSION,
-        version.asCurlType(),
+        version,
     ));
 }
 

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -362,6 +362,7 @@ pub fn setUpload(self: Self, up: *Upload) !void {
 pub fn setHttpVersion(self: Self, version: HttpVersion) !void {
     try checkCode(c.curl_easy_setopt(
         self.handle,
+        c.CURLOPT_HTTP_VERSION,
         version.asCurlType(),
     ));
 }

--- a/src/Easy.zig
+++ b/src/Easy.zig
@@ -21,6 +21,7 @@ user_agent: [:0]const u8,
 ca_bundle: ?ResizableBuffer,
 
 pub const HttpVersion = enum(c_long) {
+    none = c. CURL_HTTP_VERSION_NONE,
     http1_0 = c.CURL_HTTP_VERSION_1_0,
     http1_1 = c.CURL_HTTP_VERSION_1_1,
     http2 = c.CURL_HTTP_VERSION_2_0,


### PR DESCRIPTION
Hey, thanks for the helpful library! I am working on [httpspec](https://github.com/bradcypert/httpspec) and I needed to be able to set the HTTP version on the curl library. I couldnt find an easy way to do that without modifying the library, so I went ahead and did that (and here's a patch to support it!).